### PR TITLE
Update lgtm.yml

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -32,4 +32,4 @@ extraction:
 
     index:
       build_command:
-        - $GNU_MAKE -j$(nproc)
+        - make -j$(nproc)


### PR DESCRIPTION
I just tried running an attempt build for the C/C++ for this project on LGTM, and it seems that the current configuration is causing problems:

log: https://lgtm.com/logs/a37014a7b451a98dc63b06504b2d2d6a03ae2776/lang:cpp

I believe that `$GNU_MAKE` is not defined as an environment variable on LGTM's build environment, but a classic `make` should do the trick.

Once this is merged I can attempt the build again.