### PR TITLE
Verilog-gen Update

### DIFF
--- a/include/ilang/verilog-out/verilog_gen.h
+++ b/include/ilang/verilog-out/verilog_gen.h
@@ -129,9 +129,9 @@ public:
 
   /// Type for caching the generated expressions.
   typedef std::unordered_map<const ExprPtr, vlg_name_t, VerilogGenHash> ExprMap;
-  /// Type for cacheing the constant 
+  /// Type for cacheing the constant
   // (this is needed because our hash is not fully working)
-  typedef std::map<std::pair<IlaBvValType, unsigned>,vlg_name_t> CnstMap;
+  typedef std::map<std::pair<IlaBvValType, unsigned>, vlg_name_t> CnstMap;
   /// Type for memory annotation
   typedef std::map<std::string, bool> memory_export_annotation_t;
 
@@ -161,7 +161,8 @@ public:
         bool gen_start = false, bool pass_name = false, bool rand_init = false,
         bool ExpandMem = false)
         : extMem(ExternalMem), fcOpt(funcOpt), start_signal(gen_start),
-          pass_node_name(pass_name), reg_random_init(rand_init), expand_mem(ExpandMem) {}
+          pass_node_name(pass_name), reg_random_init(rand_init),
+          expand_mem(ExpandMem) {}
     /// Overwrite configuration, used by vtarget gen
     VlgGenConfig(const VlgGenConfig& c, bool ExternalMem, funcOption funcOpt,
                  bool gen_start, bool rand_init, bool ExpandMem)
@@ -293,7 +294,6 @@ public:
   /// will force to be hex
   static vlg_const_t ToVlgNum(IlaBvValType value, unsigned width);
 
-
 protected:
   /// The id counter
   unsigned idCounter;
@@ -354,7 +354,7 @@ public:
 
   // --------------------- ANNOTATION INTERFACE ---------------------------- //
   /// add memory annotation, please invoke right after constructor
-  void AnnotateMemory(const memory_export_annotation_t & annotation);
+  void AnnotateMemory(const memory_export_annotation_t& annotation);
 }; // class VerilogGeneratorBase
 
 /// \brief Class of Verilog Generator

--- a/include/ilang/verilog-out/verilog_gen.h
+++ b/include/ilang/verilog-out/verilog_gen.h
@@ -131,7 +131,7 @@ public:
   typedef std::unordered_map<const ExprPtr, vlg_name_t, VerilogGenHash> ExprMap;
   /// Type for cacheing the constant 
   // (this is needed because our hash is not fully working)
-  // typedef std::unordered_map<std::pair<IlaBvValType, unsigned>,vlg_name_t> CnstMap;
+  typedef std::map<std::pair<IlaBvValType, unsigned>,vlg_name_t> CnstMap;
   /// Type for memory annotation
   typedef std::map<std::string, bool> memory_export_annotation_t;
 
@@ -248,6 +248,9 @@ protected:
   vlg_stmt_t preheader;
   /// The map to cache the expression (we only need to store the name)
   ExprMap nmap;
+  /// The map to cache the constants (o.w. there will be overhead, as each
+  /// constant may appear multiple times)
+  CnstMap cmap;
 
   /// For traverse a mem expression
   mem_write_list_t current_writes;

--- a/src/verilog-out/verilog_gen.cc
+++ b/src/verilog-out/verilog_gen.cc
@@ -890,13 +890,20 @@ void VerilogGenerator::ParseNonMemUpdateExpr(
       int width = get_width(e);
       ILA_ASSERT(width > 0);
       IlaBvValType value = (std::dynamic_pointer_cast<ExprConst>(e)->val_bv()->val());
-      vlg_const_t bvcnst = ToVlgNum(value, (unsigned)width );
+      vlg_name_t result_var; 
 
-      vlg_name_t result_var = "bv_"+toStr(width)+"_"+ toStr(IlaBvValUnsignedType(value)) + new_id(e);
-      add_wire(result_var, get_width(e));
-      add_assign_stmt(result_var, bvcnst);
+      auto pos = cmap.find(std::make_pair(value, (unsigned)width));
+      if(pos == cmap.end()) { // not found
+        vlg_const_t bvcnst = ToVlgNum(value, (unsigned)width );
+        result_var = "bv_"+toStr(width)+"_"+ toStr(IlaBvValUnsignedType(value)) + "_" + new_id(e);
+        add_wire(result_var, get_width(e));
+        add_assign_stmt(result_var, bvcnst);
 
-      ILA_DLOG("VerilogGen.ParseNonMemUpdateExpr") << "BVconst: " << bvcnst << " as " << result_var;
+        ILA_DLOG("VerilogGen.ParseNonMemUpdateExpr") << "BVconst: " << bvcnst << " as " << result_var;
+        cmap.insert(std::make_pair(std::make_pair(value, (unsigned)width),result_var));
+      } else { // found
+        result_var = pos->second;
+      }
       nmap[e] = result_var;
     } else
       ILA_ASSERT(false) << "Expr sort: " << (e->sort()) << " is not supported.";

--- a/src/verilog-out/verilog_gen.cc
+++ b/src/verilog-out/verilog_gen.cc
@@ -37,9 +37,9 @@ VerilogGeneratorBase::VerilogGeneratorBase(const VlgGenConfig& config,
   }
 }
 
-
 /// add memory annotation, please invoke right after constructor
-void VerilogGeneratorBase::AnnotateMemory(const memory_export_annotation_t & annotation) {
+void VerilogGeneratorBase::AnnotateMemory(
+    const memory_export_annotation_t& annotation) {
   memory_export_annotation = annotation;
 }
 
@@ -104,26 +104,31 @@ VerilogGeneratorBase::sanitizeName(const ExprPtr& n) {
   return sanitizeName(n->name().str());
 }
 
-
 /// will force to be hex
-VerilogGeneratorBase::vlg_const_t VerilogGeneratorBase::ToVlgNum(IlaBvValType value, unsigned width) {
+VerilogGeneratorBase::vlg_const_t
+VerilogGeneratorBase::ToVlgNum(IlaBvValType value, unsigned width) {
   // get right of the types
 
   { // range check assuming signed int
-    static_assert(IlaBvValType(-1) > IlaBvValType(0) , 
-      "expecting BvValType to be unsigned value, o.w. this part of code must be updated!");
-    static_assert(sizeof(IlaBvValUnsignedType) == sizeof(IlaBvValType), 
-      "IlaBvValUnsignedType in the header needs update to be sync with IlaBvValType!");
-    IlaBvValType maxpos = (width >= sizeof(IlaBvValType)*8) ? IlaBvValType(-1) : ((1 << width) -1);
+    static_assert(IlaBvValType(-1) > IlaBvValType(0),
+                  "expecting BvValType to be unsigned value, o.w. this part of "
+                  "code must be updated!");
+    static_assert(sizeof(IlaBvValUnsignedType) == sizeof(IlaBvValType),
+                  "IlaBvValUnsignedType in the header needs update to be sync "
+                  "with IlaBvValType!");
+    IlaBvValType maxpos = (width >= sizeof(IlaBvValType) * 8)
+                              ? IlaBvValType(-1)
+                              : ((1 << width) - 1);
     IlaBvValType minneg = 0;
-    ILA_ASSERT((minneg <= value && maxpos >= value)) << "value : " << value 
-      << " is out-of-range, min:" << minneg
-      << " max:" << maxpos;
-    ILA_DLOG("VerilogGen.ToVlgNum") << "width:" << width << ", min:" << minneg << ", max:" << maxpos << std::endl;
+    ILA_ASSERT((minneg <= value && maxpos >= value))
+        << "value : " << value << " is out-of-range, min:" << minneg
+        << " max:" << maxpos;
+    ILA_DLOG("VerilogGen.ToVlgNum") << "width:" << width << ", min:" << minneg
+                                    << ", max:" << maxpos << std::endl;
   }
 
-  std::string valstr = IntToStrCustomBase(value, 16 , false);
-  return (toStr(width) + "'h" +valstr);
+  std::string valstr = IntToStrCustomBase(value, 16, false);
+  return (toStr(width) + "'h" + valstr);
 }
 
 #if 0 
@@ -175,8 +180,7 @@ VerilogGeneratorBase::vlg_const_t VerilogGeneratorBase::ToVlgNum(IlaBvValType va
   }
   return (toStr(width) + "'h" +valstr);
 }
-#endif 
-
+#endif
 
 // Currently not used, can be added to enforce sanity check
 #define CHECK_NAME(s)                                                          \
@@ -287,12 +291,14 @@ void VerilogGeneratorBase::add_ite_stmt(const vlg_stmt_t& cond,
 void VerilogGeneratorBase::add_internal_mem(const vlg_name_t& mem_name,
                                             int addr_width, int data_width,
                                             int entry_num) {
-  mems_internal.insert({mem_name, vlg_mem_t(mem_name, addr_width, data_width,entry_num)});
+  mems_internal.insert(
+      {mem_name, vlg_mem_t(mem_name, addr_width, data_width, entry_num)});
 }
 void VerilogGeneratorBase::add_external_mem(const vlg_name_t& mem_name,
                                             int addr_width, int data_width,
                                             int entry_num) {
-  mems_external.insert({mem_name, vlg_mem_t(mem_name, addr_width, data_width, entry_num)});
+  mems_external.insert(
+      {mem_name, vlg_mem_t(mem_name, addr_width, data_width, entry_num)});
   /* NO, this should not be done
   vlg_name_t addr_name = mem_name + "_addr_" + new_id();
   vlg_name_t data_name = mem_name + "_data_" + new_id();
@@ -370,15 +376,16 @@ void VerilogGeneratorBase::DumpToFile(std::ostream& fout) const {
     int entry_num_specified = std::get<3>(mem.second);
     int n_elem_allowed = std::pow(2, addr_width);
     int n_elem = n_elem_allowed;
-    ILA_ERROR_IF(entry_num_specified != 0 && entry_num_specified > n_elem_allowed)
-      << "Memory : " << std::get<0>(mem.second) << ", addr_width:" << addr_width
-      << " is forced to have " << entry_num_specified << " entries, which is greater than "
-      << "the maximum allowed entry count: " << n_elem_allowed;
+    ILA_ERROR_IF(entry_num_specified != 0 &&
+                 entry_num_specified > n_elem_allowed)
+        << "Memory : " << std::get<0>(mem.second)
+        << ", addr_width:" << addr_width << " is forced to have "
+        << entry_num_specified << " entries, which is greater than "
+        << "the maximum allowed entry count: " << n_elem_allowed;
     if (entry_num_specified != 0 && entry_num_specified <= n_elem_allowed)
       n_elem = entry_num_specified;
-    fout << "reg " << std::setw(10) << WidthToRange(data_width)
-         << " " << (std::get<0>(mem.second))
-         << WidthToRange(n_elem) << ";\n";
+    fout << "reg " << std::setw(10) << WidthToRange(data_width) << " "
+         << (std::get<0>(mem.second)) << WidthToRange(n_elem) << ";\n";
   }
   // we require that the statements must have ";" ending itself
   for (auto const& stmt : statements)
@@ -442,8 +449,7 @@ void VerilogGenerator::insertInput(const ExprPtr& input) {
     // when in expr parse, remember it is (EXTERNAL mem)
     add_external_mem(sanitizeName(input),         // name
                      input->sort()->addr_width(), // addr_width
-                     input->sort()->data_width(),
-                     ExprFuse::GetMemSize(input));
+                     input->sort()->data_width(), ExprFuse::GetMemSize(input));
   } else {
     add_input(sanitizeName(input), get_width(input));
     add_wire(sanitizeName(input), get_width(input));
@@ -456,7 +462,7 @@ void VerilogGenerator::insertState(const ExprPtr& state) {
                          // mem_external/mem_internal by default
 
     bool external = cfg_.extMem;
-    if (IN(state->name().str(),memory_export_annotation))
+    if (IN(state->name().str(), memory_export_annotation))
       external = memory_export_annotation.at(state->name().str());
     // we can overwrite the default
 
@@ -479,14 +485,16 @@ void VerilogGenerator::insertState(const ExprPtr& state) {
         if (n_elem_specified != 0 && n_elem_specified <= addr_range)
           addr_range = n_elem_specified;
         int data_width = state->sort()->data_width();
-        for (int idx = 0; idx < addr_range ; ++ idx ) {
-          auto probe_wire_name = sanitizeName(state)+"_" + std::to_string(idx);
+        for (int idx = 0; idx < addr_range; ++idx) {
+          auto probe_wire_name =
+              sanitizeName(state) + "_" + std::to_string(idx);
           mem_probe_o.push_back(vlg_sig_t(probe_wire_name, data_width));
           add_wire(probe_wire_name, data_width);
-          add_assign_stmt(probe_wire_name, sanitizeName(state) + "[" +std::to_string(idx) + "]" );
+          add_assign_stmt(probe_wire_name, sanitizeName(state) + "[" +
+                                               std::to_string(idx) + "]");
         } // for each memory element
-      } // if expand memory
-    } // else (internal memory)
+      }   // if expand memory
+    }     // else (internal memory)
   } else if (state->is_bv()) {
     auto reg_name = sanitizeName(state);
     add_reg(reg_name, state->sort()->bit_width());
@@ -889,18 +897,22 @@ void VerilogGenerator::ParseNonMemUpdateExpr(
     } else if (e->is_const()) {
       int width = get_width(e);
       ILA_ASSERT(width > 0);
-      IlaBvValType value = (std::dynamic_pointer_cast<ExprConst>(e)->val_bv()->val());
-      vlg_name_t result_var; 
+      IlaBvValType value =
+          (std::dynamic_pointer_cast<ExprConst>(e)->val_bv()->val());
+      vlg_name_t result_var;
 
       auto pos = cmap.find(std::make_pair(value, (unsigned)width));
-      if(pos == cmap.end()) { // not found
-        vlg_const_t bvcnst = ToVlgNum(value, (unsigned)width );
-        result_var = "bv_"+toStr(width)+"_"+ toStr(IlaBvValUnsignedType(value)) + "_" + new_id(e);
+      if (pos == cmap.end()) { // not found
+        vlg_const_t bvcnst = ToVlgNum(value, (unsigned)width);
+        result_var = "bv_" + toStr(width) + "_" +
+                     toStr(IlaBvValUnsignedType(value)) + "_" + new_id(e);
         add_wire(result_var, get_width(e));
         add_assign_stmt(result_var, bvcnst);
 
-        ILA_DLOG("VerilogGen.ParseNonMemUpdateExpr") << "BVconst: " << bvcnst << " as " << result_var;
-        cmap.insert(std::make_pair(std::make_pair(value, (unsigned)width),result_var));
+        ILA_DLOG("VerilogGen.ParseNonMemUpdateExpr")
+            << "BVconst: " << bvcnst << " as " << result_var;
+        cmap.insert(
+            std::make_pair(std::make_pair(value, (unsigned)width), result_var));
       } else { // found
         result_var = pos->second;
       }


### PR DESCRIPTION
Improvement:
- avoid duplicated wires for the same constant 

Initially, constants are inline, but that does not allow bit-select from verilog constant, an update later used wire to hold constants, but may create multiple wires for the same constants if they are different nodes, this update creates a map to de-duplicate.