### PR TITLE
Verilog gen bug fix

### DIFF
--- a/src/verilog-out/verilog_gen.cc
+++ b/src/verilog-out/verilog_gen.cc
@@ -118,7 +118,7 @@ VerilogGeneratorBase::ToVlgNum(IlaBvValType value, unsigned width) {
                   "with IlaBvValType!");
     IlaBvValType maxpos = (width >= sizeof(IlaBvValType) * 8)
                               ? IlaBvValType(-1)
-                              : ((1 << width) - 1);
+                              : (( (IlaBvValType)(1) << width) - 1);
     IlaBvValType minneg = 0;
     ILA_ASSERT((minneg <= value && maxpos >= value))
         << "value : " << value << " is out-of-range, min:" << minneg


### PR DESCRIPTION
Bug fix
- the max value check used a constant without specify the right width of it.