### PR TITLE
Update Boolector install steps in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ brew install bison flex boost boost-python z3
 | Ubuntu 16.04 (Xenial)     | clang 7.0.0  | 3.12.4 | 4.4.1 | 1.58  | 3.0.4 | 2.6.0  | Debug   |
 | Ubuntu 16.04 (Xenial)     | gcc 5.4.0    | 3.12.4 | 4.4.1 | 1.69  | 3.0.4 | 2.6.0  | Release |
 | Ubuntu 18.04 (Bionic)     | gcc 7.4.0    | 3.15.2 | 4.8.6 | 1.65  | 3.0.4 | 2.6.4  | Release |
-| OSX 10.13.3 (High Sierra) | Xcode 9.4.1  | 3.11.3 | 4.8.6 | 1.71  | 3.4.2 | 2.5.35 | Debug   |
-| OSX 10.13.6 (High Sierra) | Xcode 10.1.0 | 3.14.5 | 4.8.6 | 1.71  | 3.4.2 | 2.5.35 | Release |
-| OSX 10.14.5 (Mojave)      | Xcode 10.2.1 | 3.14.5 | 4.8.6 | 1.71  | 3.4.2 | 2.5.35 | Release |
+| OSX 10.13.3 (High Sierra) | Xcode 9.4.1  | 3.11.3 | 4.8.7 | 1.72  | 3.5.0 | 2.5.35 | Debug   |
+| OSX 10.13.6 (High Sierra) | Xcode 10.1.0 | 3.16.2 | 4.8.7 | 1.72  | 3.5.0 | 2.5.35 | Release |
+| OSX 10.14.5 (Mojave)      | Xcode 10.2.1 | 3.16.2 | 4.8.7 | 1.72  | 3.5.0 | 2.5.35 | Release |
 | Windows Server 2016       | VS 2017      | 3.14.5 | 4.8.6 | -     | 3.3.2 | 2.6.4  | Release |
 
 ### Default Build
@@ -242,7 +242,7 @@ ILAng uses the [VCD parser](https://github.com/ben-marshall/verilog-vcd-parser),
 Copyright (c) 2018 Ben Marshall.
 
 ILAng uses the [SMT parser](https://es-static.fbk.eu/people/griggio/misc/smtlib2parser.html), which is licensed under the [MIT License](https://es-static.fbk.eu/people/griggio/misc/smtlib2parser.html).
-Copyright (c) 2010 Alberto Griggio
+Copyright (c) 2010 Alberto Griggio.
 
 ILAng uses [ItSy](https://github.com/PrincetonUniversity/ItSy), which is licensed under the [MIT License](https://github.com/PrincetonUniversity/ItSy/blob/master/LICENSE).
 Copyright (c) 2016 Princeton University.

--- a/scripts/dockers/Dockerfile.cosabase
+++ b/scripts/dockers/Dockerfile.cosabase
@@ -13,6 +13,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install --yes --no-install-
     bison \
     build-essential \
     cmake \
+    curl \
     expect \
     flex \
     gawk \
@@ -38,6 +39,17 @@ WORKDIR $BUILD_ROOT
 RUN pip3 install virtualenv
 RUN virtualenv $VIRT_ENV
 
+# z3
+ENV Z3_DIR $BUILD_ROOT/z3
+WORKDIR $BUILD_ROOT
+ADD https://api.github.com/repos/Z3Prover/z3/git/refs/heads/master z3_version.json
+RUN git clone https://github.com/Z3Prover/z3.git $Z3_DIR
+WORKDIR $Z3_DIR
+RUN python scripts/mk_make.py --prefix $BUILD_PREF
+WORKDIR $Z3_DIR/build
+RUN make -j"$(nproc)" && \
+    make install
+
 # Yosys
 ENV YOSYS_DIR $BUILD_ROOT/yosys
 WORKDIR $BUILD_ROOT
@@ -60,7 +72,7 @@ RUN $BUILD_PREF/bin/pip3 install -e .
 WORKDIR $BUILD_ROOT
 RUN wget https://raw.githubusercontent.com/Bo-Yuan-Huang/pysmt/master/pysmt/cmd/installers/btor.py
 RUN mv btor.py $BUILD_PREF/lib/python3.6/site-packages/pysmt/cmd/installers/btor.py
-RUN wget https://raw.githubusercontent.com/makaimann/pysmt/fast/pysmt/solvers/btor.py 
+RUN wget https://raw.githubusercontent.com/Bo-Yuan-Huang/pysmt/master/pysmt/solvers/btor.py
 RUN mv btor.py $BUILD_PREF/lib/python3.6/site-packages/pysmt/solvers/btor.py
 RUN $BUILD_PREF/bin/pip3 install cython
 
@@ -73,6 +85,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install --yes --no-install-
     bison \
     build-essential \
     cmake \
+    curl \
     flex \
     git \
     libboost-all-dev \
@@ -96,6 +109,7 @@ WORKDIR /root/workspace
 
 RUN echo "source $BUILD_PREF/bin/activate" >> init.sh
 RUN echo "export PYTHONPATH=$BUILD_PREF/lib:\$PYTHONPATH" >> init.sh
+RUN echo "export LD_LIBRARY_PATH=$BUILD_PREF/lib:\$LD_LIBRARY_PATH" >> init.sh
 RUN echo "export CMAKE_PREFIX_PATH=$BUILD_PREF:\$CMAKE_PREFIX_PATH" >> init.sh
 RUN echo "cd $(pwd)" >> init.sh
 

--- a/scripts/dockers/Dockerfile.dev
+++ b/scripts/dockers/Dockerfile.dev
@@ -5,11 +5,6 @@ ENV VIRT_ENV ilang-env
 ENV BUILD_ROOT /ibuild
 ENV BUILD_PREF $BUILD_ROOT/$VIRT_ENV
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install --yes --no-install-recommends \
-  libz3-dev \
-  z3 \
-  && rm -rf /var/lib/apt/lists/*
-
 # root dir
 WORKDIR $BUILD_ROOT
 
@@ -31,7 +26,7 @@ WORKDIR $BUILD_ROOT
 ADD https://api.github.com/repos/PrincetonUniversity/ItSy/git/refs/heads/master itsy_version.json
 RUN git clone https://github.com/PrincetonUniversity/ItSy.git $ITSY_DIR
 WORKDIR $ITSY_DIR
-RUN bjam -j"$(nproc)"
+RUN CPLUS_INCLUDE_PATH=$BUILD_PREF/include LIBRARY_PATH=$BUILD_PREF/lib LD_LIBRARY_PATH=$BUILD_PREF/lib bjam -j"$(nproc)"
 RUN cp build/ila.so $BUILD_PREF/lib
 
 # deploy

--- a/scripts/dockers/Dockerfile.latest
+++ b/scripts/dockers/Dockerfile.latest
@@ -5,11 +5,6 @@ ENV VIRT_ENV ilang-env
 ENV BUILD_ROOT /ibuild
 ENV BUILD_PREF $BUILD_ROOT/$VIRT_ENV
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install --yes --no-install-recommends \
-  libz3-dev \
-  z3 \
-  && rm -rf /var/lib/apt/lists/*
-
 # root dir
 WORKDIR $BUILD_ROOT
 
@@ -31,7 +26,7 @@ WORKDIR $BUILD_ROOT
 ADD https://api.github.com/repos/PrincetonUniversity/ItSy/git/refs/heads/master itsy_version.json
 RUN git clone https://github.com/PrincetonUniversity/ItSy.git $ITSY_DIR
 WORKDIR $ITSY_DIR
-RUN bjam -j"$(nproc)"
+RUN CPLUS_INCLUDE_PATH=$BUILD_PREF/include LIBRARY_PATH=$BUILD_PREF/lib LD_LIBRARY_PATH=$BUILD_PREF/lib bjam -j"$(nproc)"
 RUN cp build/ila.so $BUILD_PREF/lib
 
 # template-ila (example)
@@ -52,11 +47,6 @@ FROM byhuang/ilang:cosabase
 ENV VIRT_ENV ilang-env
 ENV BUILD_ROOT /ibuild
 ENV BUILD_PREF $BUILD_ROOT/$VIRT_ENV
-
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install --yes --no-install-recommends \
-  libz3-dev \
-  z3 \
-  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/workspace
 

--- a/scripts/dockers/Dockerfile.rolling
+++ b/scripts/dockers/Dockerfile.rolling
@@ -44,8 +44,8 @@ ENV Z3_DIR $BUILD_ROOT/z3
 WORKDIR $BUILD_ROOT
 ADD https://api.github.com/repos/Z3Prover/z3/git/refs/heads/master z3_version.json
 RUN git clone https://github.com/Z3Prover/z3.git $Z3_DIR
-WORKDIR $Z3_DIR 
-RUN $BUILD_PREF/bin/python scripts/mk_make.py --prefix=$BUILD_PREF --python 
+WORKDIR $Z3_DIR
+RUN python scripts/mk_make.py --prefix $BUILD_PREF
 WORKDIR $Z3_DIR/build
 RUN make -j"$(nproc)" && \
     make install
@@ -53,9 +53,8 @@ RUN make -j"$(nproc)" && \
 # Yosys
 ENV YOSYS_DIR $BUILD_ROOT/yosys
 WORKDIR $BUILD_ROOT
-RUN wget https://github.com/cliffordwolf/yosys/archive/yosys-0.8.tar.gz
-RUN mkdir -p $YOSYS_DIR 
-RUN tar zxvf yosys-0.8.tar.gz -C $YOSYS_DIR --strip-components 1
+ADD https://api.github.com/repos/cliffordwolf/yosys/git/refs/heads/master yosys_version.json
+RUN git clone https://github.com/YosysHQ/yosys.git $YOSYS_DIR
 WORKDIR $YOSYS_DIR 
 RUN make config-gcc && \
     make -j"$(nproc)" && \
@@ -67,32 +66,15 @@ WORKDIR $BUILD_ROOT
 ADD https://api.github.com/repos/cristian-mattarei/CoSA/git/refs/heads/master cosa_version.json
 RUN git clone https://github.com/cristian-mattarei/CoSA.git $COSA_DIR
 WORKDIR $COSA_DIR
-RUN git checkout remotes/origin/dev -b dev
 RUN $BUILD_PREF/bin/pip3 install -e .
 
-# Boolector
-ENV BTOR_DIR $BUILD_ROOT/Boolector
+# PySMT - Boolector
 WORKDIR $BUILD_ROOT
-ADD https://api.github.com/repos/Boolector/boolector/git/refs/heads/master btor_version.json
-RUN git clone --depth=1 https://github.com/Boolector/boolector.git $BTOR_DIR
-RUN pip3 install cython==0.29.3
-WORKDIR $BTOR_DIR
-RUN ./contrib/setup-lingeling.sh 
-RUN ./contrib/setup-cadical.sh
-RUN ./contrib/setup-btor2tools.sh
-RUN ./configure.sh --python --py3 --prefix $BUILD_PREF
-WORKDIR $BTOR_DIR/build
-RUN make -j"$(nproc)" && \
-    make install
-
-# PySMT
-WORKDIR $BUILD_ROOT
-RUN wget https://raw.githubusercontent.com/makaimann/pysmt/fast/pysmt/solvers/btor.py 
-RUN mv btor.py btor-solver.py
-RUN cp btor-solver.py $BUILD_PREF/lib/python3.6/site-packages/pysmt/solvers/btor.py
-RUN wget https://raw.githubusercontent.com/makaimann/pysmt/fast/pysmt/cmd/installers/btor.py 
-RUN mv btor.py btor-installer.py
-RUN cp btor-installer.py /ibuild/ilang-env/lib/python3.6/site-packages/pysmt/cmd/installers/btor.py
+RUN wget https://raw.githubusercontent.com/Bo-Yuan-Huang/pysmt/master/pysmt/cmd/installers/btor.py
+RUN mv btor.py $BUILD_PREF/lib/python3.6/site-packages/pysmt/cmd/installers/btor.py
+RUN wget https://raw.githubusercontent.com/Bo-Yuan-Huang/pysmt/master/pysmt/solvers/btor.py
+RUN mv btor.py $BUILD_PREF/lib/python3.6/site-packages/pysmt/solvers/btor.py
+RUN $BUILD_PREF/bin/pip3 install cython
 
 # ILAng
 ENV ILANG_DIR $BUILD_ROOT/ILAng
@@ -124,6 +106,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install --yes --no-install-
     bison \
     build-essential \
     cmake \
+    curl \
     flex \
     git \
     libboost-all-dev \


### PR DESCRIPTION
- use PySMT embedded installation
- modify btor install commands
- modify btor solver interface
- use latest z3 in the docker images instead of canonical packages