### PR TITLE
Fix bug #180: Ilator miscall to_int() when storing constants

### DIFF
--- a/src/target-sc/dfs.cc
+++ b/src/target-sc/dfs.cc
@@ -287,9 +287,13 @@ void IlaSim::dfs_binary_op_mem(std::stringstream& dfs_simulator,
     arg1_str =
         (arg1_str == "true") ? "1" : (arg1_str == "false") ? "0" : arg1_str;
   else
-    arg1_str = (arg1_str == "true") ? "1" : (arg1_str == "false")
-                                                ? "0"
-                                                : arg1_str + ".to_int()";
+    arg1_str = (arg1_str == "true")
+                   ? "1"
+                   : (arg1_str == "false")
+                         ? "0"
+                         : (GetUidExpr(expr->arg(1)) == AST_UID_EXPR::CONST)
+                               ? arg1_str
+                               : arg1_str + ".to_int()";
 
   std::string out_str = "c_" + std::to_string(expr->name().id());
   std::string out_type_str =
@@ -347,9 +351,14 @@ void IlaSim::dfs_binary_op_mem(std::stringstream& dfs_simulator,
       arg2_str =
           (arg2_str == "true") ? "1" : (arg2_str == "false") ? "0" : arg2_str;
     else
-      arg2_str = (arg2_str == "true") ? "1" : (arg2_str == "false")
-                                                  ? "0"
-                                                  : arg2_str + ".to_int()";
+      arg2_str = (arg2_str == "true")
+                     ? "1"
+                     : (arg2_str == "false")
+                           ? "0"
+                           : (GetUidExpr(expr->arg(2)) == AST_UID_EXPR::CONST)
+                                 ? arg2_str
+
+                                 : arg2_str + ".to_int()";
     dfs_simulator << indent << "mem_update_map[" << arg1_str
                   << "] = " << arg2_str << ";" << std::endl;
   }


### PR DESCRIPTION
[Fix #180: ](https://github.com/Bo-Yuan-Huang/ILAng/issues/180)
