### PR TITLE
Enable TestVlgTargetGen.MemoryInternal

### DIFF
--- a/test/t_vtarget_gen.cc
+++ b/test/t_vtarget_gen.cc
@@ -324,8 +324,8 @@ TEST(TestVlgTargetGen, Memory) {
   vg.GenerateTargets();
 }
 
-TEST(TestVlgTargetGen,
-     DISABLED_MemoryInternal) { // test the expansion of memory
+TEST(TestVlgTargetGen, MemoryInternal) { // test the expansion of memory
+
   auto ila_model = MemorySwap::BuildSimpleSwapModel();
 
   VerilogVerificationTargetGenerator::vtg_config_t


### PR DESCRIPTION
Enable the unit test `TestVlgTargetGen.MemoryInternal` to investigate whether the previous segmentation fault in #178 is a false alarm. Run through the updated CI checks.