### PR TITLE
Fix bug #179: miss constant bit_width in ILAtor Concat-op

### DIFF
--- a/src/target-sc/dfs.cc
+++ b/src/target-sc/dfs.cc
@@ -273,8 +273,16 @@ void IlaSim::dfs_binary_op_non_mem(std::stringstream& dfs_simulator,
                     << arg1_str << ");" << std::endl;
     }
   } else {
-    dfs_simulator << indent << out_str << " = (" << arg0_str << op_str
-                  << arg1_str << ");" << std::endl;
+    if (GetUidExprOp(expr) == AST_UID_EXPR_OP::CONCAT) {
+      auto arg0_width = expr->arg(0)->sort()->bit_width();
+      auto arg1_width = expr->arg(1)->sort()->bit_width();
+      dfs_simulator << indent << out_str << " = (sc_biguint<" << arg0_width
+                    << ">(" << arg0_str << ")" << op_str << "sc_biguint<"
+                    << arg1_width << ">(" << arg1_str << "));" << std::endl;
+    } else {
+      dfs_simulator << indent << out_str << " = (" << arg0_str << op_str
+                    << arg1_str << ");" << std::endl;
+    }
   }
 }
 
@@ -357,7 +365,6 @@ void IlaSim::dfs_binary_op_mem(std::stringstream& dfs_simulator,
                            ? "0"
                            : (GetUidExpr(expr->arg(2)) == AST_UID_EXPR::CONST)
                                  ? arg2_str
-
                                  : arg2_str + ".to_int()";
     dfs_simulator << indent << "mem_update_map[" << arg1_str
                   << "] = " << arg2_str << ";" << std::endl;


### PR DESCRIPTION
fix-bug: keep bv_width for Ilator constants for Concat operation