### PR TITLE
SMT-LIB2 Parser Bug Fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,6 +92,7 @@ jobs:
       cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-8
       cmake --build .
       sudo cmake --build . --target install 
+      ./test/unit_tests
       cmake --build . --target test
     displayName: 'build'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
       export LDFLAGS="-L/usr/local/opt/bison/lib"
       mkdir -p build
       cd build
-      cmake .. -DCMAKE_BUILD_TYPE=Release -DILANG_BUILD_INVSYN=OFF 
+      cmake .. -DCMAKE_BUILD_TYPE=Release
       cmake --build .
       cmake --build . --target install 
       ./test/unit_tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,6 @@ jobs:
       cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-8
       cmake --build .
       sudo cmake --build . --target install 
-      ./test/unit_tests
       cmake --build . --target test
     displayName: 'build'
 

--- a/extern/smt-parser/azure-pipelines.yml
+++ b/extern/smt-parser/azure-pipelines.yml
@@ -8,9 +8,9 @@ pr:
 
 jobs:
 
-- job: macOS
+- job: macOS_Catalina_Debug
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.15'
   steps:
   - script: |
       brew update

--- a/extern/smt-parser/configure.sh
+++ b/extern/smt-parser/configure.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+BUILD_DIR=build
+
+debug=no
+static=no
+
+#--------------------------------------------------------------------------#
+
+die () {
+  echo "*** configure.sh: $*" 1>&2
+  exit 1
+}
+
+usage () {
+cat <<EOF
+usage: ./configure.sh [<option> ...]
+
+where <option> is one of the following:
+
+  -O                optimized compilation (default)
+  -g                compile with debugging support
+  --static          static compilation
+
+You might also want to use the environment variables
+CC and CXX to specify the used C and C++ compiler, as in
+
+  CC=gcc-4.4 CXX=g++-4.4 ./configure.sh
+
+which forces to use 'gcc-4.4' and 'g++-4.4'.
+EOF
+  exit 0
+}
+
+#--------------------------------------------------------------------------#
+
+while [ $# -gt 0 ]
+do
+  case $1 in
+    -g) debug=yes;;
+    -O) debug=no;;
+    --static) static=yes;;
+    -h|-help|--help) usage;;
+    -*) die "invalid option '$1' (try '-h')";;
+  esac
+  shift
+done
+
+#--------------------------------------------------------------------------#
+
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}"
+
+cmake_opts=""
+[ $debug = yes ] && cmake_opts="$cmake_opts -DCMAKE_BUILD_TYPE=Debug"
+[ $static = yes ] && cmake_opts="$cmake_opts -DBUILD_SHARED_LIBS=OFF"
+
+cd "${BUILD_DIR}"
+cmake .. $cmake_opts

--- a/extern/smt-parser/include/smtparser/smtlib2abstractparser.h
+++ b/extern/smt-parser/include/smtparser/smtlib2abstractparser.h
@@ -40,4 +40,6 @@ void smtlib2_abstract_parser_deinit(smtlib2_abstract_parser *p);
 void smtlib2_abstract_parser_parse(smtlib2_abstract_parser *p, FILE *src);
 void smtlib2_abstract_parser_parse_string(smtlib2_abstract_parser *p, const char * str);
 
+smtlib2_parser_interface * SMTLIB2_PARSER_INTERFACE(smtlib2_abstract_parser *p);
+
 #endif /* SMTLIB2ABSTRACTPARSER_H_INCLUDED */

--- a/extern/smt-parser/include/smtparser/smtlib2abstractparser_private.h
+++ b/extern/smt-parser/include/smtparser/smtlib2abstractparser_private.h
@@ -136,10 +136,10 @@ void smtlib2_abstract_parser_handle_error(smtlib2_parser_interface *p,
                                           const char *msg);
 
 void smtlib2_abstract_parser_push_let_scope(smtlib2_parser_interface *p);
-void smtlib2_abstract_parser_pop_let_scope(smtlib2_parser_interface *p);
+smtlib2_term smtlib2_abstract_parser_pop_let_scope(smtlib2_parser_interface *p);
 
 void smtlib2_abstract_parser_push_quantifier_scope(smtlib2_parser_interface *p);
-void smtlib2_abstract_parser_pop_quantifier_scope(smtlib2_parser_interface *p);
+smtlib2_term smtlib2_abstract_parser_pop_quantifier_scope(smtlib2_parser_interface *p);
 
 smtlib2_term smtlib2_abstract_parser_make_term(smtlib2_parser_interface *p,
                                                const char *symbol,

--- a/extern/smt-parser/include/smtparser/smtlib2parserinterface.h
+++ b/extern/smt-parser/include/smtparser/smtlib2parserinterface.h
@@ -34,7 +34,8 @@
 /* typedefs */
 typedef struct smtlib2_parser_interface smtlib2_parser_interface;
 
-#define SMTLIB2_PARSER_INTERFACE(p) ((smtlib2_parser_interface *)p)
+// let's replace this nasty pointer manipulation
+// #define SMTLIB2_PARSER_INTERFACE(p) ((smtlib2_parser_interface *)p)
 
 /**
  * Interface for SMT-LIB v2 parsers
@@ -213,7 +214,7 @@ struct smtlib2_parser_interface {
      * "forall" is parsed, and also when a "define-function" with parameters
      * is parsed
      */
-    smtlib2_term (*push_quantifier_scope)(smtlib2_parser_interface *parser);
+    void (*push_quantifier_scope)(smtlib2_parser_interface *parser);
 
     /**
      * pop a scope for quantified variabled. called when the closing

--- a/extern/smt-parser/include/smtparser/smtlib2yices.h
+++ b/extern/smt-parser/include/smtparser/smtlib2yices.h
@@ -54,5 +54,6 @@ typedef struct smtlib2_yices_parser {
 
 smtlib2_yices_parser *smtlib2_yices_parser_new(void);
 void smtlib2_yices_parser_delete(smtlib2_yices_parser *p);
+smtlib2_parser_interface * SMTLIB2_PARSER_INTERFACE_YICES(smtlib2_yices_parser *p);
 
 #endif /* SMTLIB2YICES_H_INCLUDED */

--- a/extern/smt-parser/src/smtlib2abstractparser.c
+++ b/extern/smt-parser/src/smtlib2abstractparser.c
@@ -32,6 +32,10 @@
 #include <string.h>
 
 
+smtlib2_parser_interface * SMTLIB2_PARSER_INTERFACE(smtlib2_abstract_parser *p) {
+    return &(p->parent_);
+}
+
 void smtlib2_abstract_parser_init(smtlib2_abstract_parser *p,
                                   smtlib2_context ctx)
 {
@@ -457,7 +461,7 @@ void smtlib2_abstract_parser_push_let_scope(smtlib2_parser_interface *p)
 }
 
 
-void smtlib2_abstract_parser_pop_let_scope(smtlib2_parser_interface *p)
+smtlib2_term smtlib2_abstract_parser_pop_let_scope(smtlib2_parser_interface *p)
 {
     smtlib2_abstract_parser *pp = (smtlib2_abstract_parser *)p;
     if (pp->response_ != SMTLIB2_RESPONSE_ERROR) {
@@ -468,6 +472,7 @@ void smtlib2_abstract_parser_pop_let_scope(smtlib2_parser_interface *p)
                 smtlib2_term_parser_get_error_msg(pp->termparser_));
         }
     }
+    return NULL;
 }
 
 
@@ -477,9 +482,10 @@ void smtlib2_abstract_parser_push_quantifier_scope(smtlib2_parser_interface *p)
 }
 
 
-void smtlib2_abstract_parser_pop_quantifier_scope(smtlib2_parser_interface *p)
+smtlib2_term smtlib2_abstract_parser_pop_quantifier_scope(smtlib2_parser_interface *p)
 {
     /* nothing to do */
+    return NULL;
 }
 
 

--- a/extern/smt-parser/src/smtlib2stream.c
+++ b/extern/smt-parser/src/smtlib2stream.c
@@ -35,13 +35,14 @@ static int smtlib2_sstream_getc(smtlib2_stream *s);
 static int smtlib2_sstream_putc(smtlib2_stream *s, char c);
 static bool smtlib2_sstream_eof(smtlib2_stream *s);
 
+#define SMTLIB2STREAM_PARENT(s) (&(s->parent_))
 
 smtlib2_fstream *smtlib2_fstream_new(FILE *f)
 {
     smtlib2_fstream *ret = (smtlib2_fstream *)malloc(sizeof(smtlib2_fstream));
-    ((smtlib2_stream *)ret)->get_char = smtlib2_fstream_getc;
-    ((smtlib2_stream *)ret)->put_char = smtlib2_fstream_putc;
-    ((smtlib2_stream *)ret)->eof = smtlib2_fstream_eof;
+    (SMTLIB2STREAM_PARENT(ret))->get_char = smtlib2_fstream_getc;
+    (SMTLIB2STREAM_PARENT(ret))->put_char = smtlib2_fstream_putc;
+    (SMTLIB2STREAM_PARENT(ret))->eof = smtlib2_fstream_eof;
     ret->f_ = f;
     return ret;
 }
@@ -56,9 +57,9 @@ void smtlib2_fstream_delete(smtlib2_fstream *s)
 smtlib2_sstream *smtlib2_sstream_new(smtlib2_charbuf *buf)
 {
     smtlib2_sstream *ret = (smtlib2_sstream *)malloc(sizeof(smtlib2_sstream));
-    ((smtlib2_stream *)ret)->get_char = smtlib2_sstream_getc;
-    ((smtlib2_stream *)ret)->put_char = smtlib2_sstream_putc;
-    ((smtlib2_stream *)ret)->eof = smtlib2_sstream_eof;
+    (SMTLIB2STREAM_PARENT(ret))->get_char = smtlib2_sstream_getc;
+    (SMTLIB2STREAM_PARENT(ret))->put_char = smtlib2_sstream_putc;
+    (SMTLIB2STREAM_PARENT(ret))->eof = smtlib2_sstream_eof;
     ret->buf_ = buf;
     ret->nextidx_ = 0;
     return ret;

--- a/extern/smt-parser/src/smtlib2yices.c
+++ b/extern/smt-parser/src/smtlib2yices.c
@@ -164,6 +164,11 @@ static uint32_t smtlib2_yices_parametric_sort_hashfun(intptr_t s);
 static bool smtlib2_yices_parametric_sort_eqfun(intptr_t s1, intptr_t s2);
 
 
+
+smtlib2_parser_interface * SMTLIB2_PARSER_INTERFACE_YICES(smtlib2_yices_parser *p) {
+    return &(p->parent_->parent_);
+}
+
 smtlib2_yices_parser *smtlib2_yices_parser_new(void)
 {
     smtlib2_yices_parser *ret =
@@ -195,7 +200,7 @@ smtlib2_yices_parser *smtlib2_yices_parser_new(void)
     ret->names_ = smtlib2_vector_new();
 
     /* initialize the term parser and override virtual methods */
-    pi = SMTLIB2_PARSER_INTERFACE(ret);
+    pi = SMTLIB2_PARSER_INTERFACE_YICES(ret);
     pi->set_logic = smtlib2_yices_parser_set_logic;
     pi->declare_sort = smtlib2_yices_parser_declare_sort;
     pi->declare_function = smtlib2_yices_parser_declare_function;

--- a/include/ilang/smt-inout/chc_inv_callback_fn.h
+++ b/include/ilang/smt-inout/chc_inv_callback_fn.h
@@ -23,7 +23,7 @@ namespace smt {
 
 // --- for abstract parser
 // (forall
-smtlib2_term proxy_push_quantifier_scope(smtlib2_parser_interface* p);
+void proxy_push_quantifier_scope(smtlib2_parser_interface* p);
 
 // ) ; end of forall
 smtlib2_term proxy_pop_quantifier_scope(smtlib2_parser_interface* p);

--- a/include/ilang/smt-inout/chc_inv_in.h
+++ b/include/ilang/smt-inout/chc_inv_in.h
@@ -56,9 +56,9 @@ public:
   /// the type for sort allocation
   typedef std::vector<var_type> sort_allocation_pool_t;
   /// the pointer type for terms (should not directly use the pointers)
-  typedef unsigned TermPtrT; // typedef term_container_t::iterator TermPtrT;
+  typedef size_t TermPtrT; // typedef term_container_t::iterator TermPtrT;
   /// the pointer type for sort
-  typedef unsigned SortPtrT; // typedef sort_container_t::iterator SortPtrT;
+  typedef size_t SortPtrT; // typedef sort_container_t::iterator SortPtrT;
 
   /// the type of container to hold the terms
   typedef std::map<std::string, TermPtrT> name2term_t;
@@ -155,8 +155,11 @@ protected:
   TermPtrT new_term(const std::string & search_name, const SmtTermInfoVerilog & term);
   /// From pointer to sort
   const var_type & get_sort(SortPtrT ptr) const;
+
+public:
   /// From pointer to term
   const SmtTermInfoVerilog & get_term(TermPtrT ptr) const;
+  // this has to be public, to allow external use by inv_obj
 
 public:
   /// check if this module is in a bad state

--- a/include/ilang/smt-inout/chc_inv_in.h
+++ b/include/ilang/smt-inout/chc_inv_in.h
@@ -22,14 +22,6 @@ namespace smt {
 // we will need a pointer to the SmtlibInvariantParser
 class SmtlibInvariantParser;
 
-/// \brief a wrapper of the abstract parser
-/// so it is okay to do crazy stuff
-struct smtlib2_abstract_parser_wrapper {
-  /// this is equivalent to its parent
-  smtlib2_abstract_parser parser;
-  /// a pointer to allow us to access to the object-oriented part
-  SmtlibInvariantParser* inv_parser;
-}; // struct smtlib2_abstract_parser_wrapper
 
 /// \brief the type of term info that needs to be carried
 template <class T> struct SmtTermInfo {
@@ -50,8 +42,6 @@ template <class T> struct SmtTermInfo {
 /// For verilog, it will be just std::string
 /// For translating to ILA, it could be ExprPtr
 typedef SmtTermInfo<std::string> SmtTermInfoVerilog;
-/// the pointer type
-typedef SmtTermInfoVerilog* SmtTermInfoVlgPtr;
 
 /// \brief the class for parsing invariant
 class SmtlibInvariantParser : public SmtlibInvariantParserBase {
@@ -60,16 +50,26 @@ public:
   /// a function to map state name (internal name reference to verilog signal)
   typedef std::function<std::string(const std::string&)>
       verilog_internal_name_lookup_fn_t;
+
+  /// the type for term_allocation
+  typedef std::vector<SmtTermInfoVerilog> term_allocation_pool_t;
+  /// the type for sort allocation
+  typedef std::vector<var_type> sort_allocation_pool_t;
+  /// the pointer type for terms (should not directly use the pointers)
+  typedef unsigned TermPtrT; // typedef term_container_t::iterator TermPtrT;
+  /// the pointer type for sort
+  typedef unsigned SortPtrT; // typedef sort_container_t::iterator SortPtrT;
+
   /// the type of container to hold the terms
-  typedef std::map<std::string, SmtTermInfoVerilog> term_container_t;
+  typedef std::map<std::string, TermPtrT> name2term_t;
   /// then we need stack for forall infos
-  typedef std::map<std::string, SmtTermInfoVerilog> quantifier_temp_def_t;
+  typedef std::map<std::string, TermPtrT> quantifier_temp_def_t;
   /// and the stack
   typedef std::vector<quantifier_temp_def_t> quantifier_def_stack_t;
   /// the sort container
-  typedef std::map<std::string, var_type> sort_container_t;
+  typedef std::map<std::string, SortPtrT> name2sort_t;
   /// the container of temporary variables
-  typedef std::map<std::string, SmtTermInfoVerilog> local_vars_t;
+  typedef std::map<std::string, TermPtrT> local_vars_t;
   /// search_string to local var name
   typedef std::map<std::string, std::string> local_vars_lookup_t;
   /// the container of all the free variables
@@ -107,17 +107,19 @@ public:
 protected:
   // ----------------- MEMBERS ------------------- //
   /// the parser interface
-  smtlib2_abstract_parser_wrapper* parser_wrapper;
+  smtlib2_abstract_parser* parser_wrapper;
   /// the term container
-  // we will allocate on this container
-  // there will be pointers going into it
-  term_container_t term_container;
-  /// we will allocate in this container
-  sort_container_t sort_container;
+  // we will allocate on these containers
+  term_allocation_pool_t term_pool;
+  /// the sort container
+  sort_allocation_pool_t sort_pool;
+
+  // keep track of the name to terms mapping
+  name2term_t name2term_map;
+  /// keep track of the name to sort mapping
+  name2sort_t name2sort_map;
   /// the temporary def stacks
   quantifier_def_stack_t quantifier_def_stack;
-  /// sentry -- probably no use
-  unsigned mask;
   /// a collection of functions that should be treated as inv predicates
   const std::set<std::string> inv_pred_name;
   /// the quantifier declare index (order)
@@ -147,6 +149,15 @@ protected:
   /// If it is bad state, return true and display a message
   bool bad_state_return(void);
 
+  /// New Sort
+  SortPtrT new_sort(const std::string & search_name, const var_type & sort);
+  /// New Term
+  TermPtrT new_term(const std::string & search_name, const SmtTermInfoVerilog & term);
+  /// From pointer to sort
+  const var_type & get_sort(SortPtrT ptr) const;
+  /// From pointer to term
+  const SmtTermInfoVerilog & get_term(TermPtrT ptr) const;
+
 public:
   /// check if this module is in a bad state
   bool in_bad_state(void) const { return _bad_state; }
@@ -154,39 +165,41 @@ public:
 public:
   // ----------------- CALLBACK FUNS INTERFACE ------------------- //
   /// call back function to handle (forall
-  virtual SmtTermInfoVlgPtr push_quantifier_scope();
+  virtual TermPtrT push_quantifier_scope();
   /// call back function to handle ) of forall
-  virtual SmtTermInfoVlgPtr pop_quantifier_scope();
+  virtual TermPtrT pop_quantifier_scope();
   /// declare function (useful for Grain)
-  virtual void declare_function(const std::string& name, var_type* sort);
+  virtual void declare_function(const std::string& name, SortPtrT sort);
   /// call back function to create a sort
-  virtual var_type* make_sort(const std::string& name, const std::vector<int>&);
+  virtual SortPtrT make_sort(const std::string& name, const std::vector<int>&);
+  /// call back function to create an array sort
+  virtual SortPtrT make_parametric_sort(const std::string& name, const std::vector<SortPtrT>& tpargs);
   /// call back function to create a temporary (quantified variable)
   virtual void declare_quantified_variable(const std::string& name,
-                                           var_type* sort);
+                                           SortPtrT sort);
   /// call back function to apply an uninterpreted function
   /// fall-through case if it is not an defined op, if failed, return NULL
-  virtual SmtTermInfoVlgPtr
-  mk_function(const std::string& name, var_type* sort,
+  virtual TermPtrT
+  mk_function(const std::string& name, SortPtrT sort,
               const std::vector<int>& idx,
-              const std::vector<SmtTermInfoVlgPtr>& args);
+              const std::vector<TermPtrT>& args);
   /// call back function to make a number term
-  virtual SmtTermInfoVlgPtr mk_number(const std::string& rep, int width,
+  virtual TermPtrT mk_number(const std::string& rep, int width,
                                       int base);
   /// find if a certain var is a quantified variable
-  virtual SmtTermInfoVlgPtr
+  virtual TermPtrT
   search_quantified_var_stack(const std::string& name);
   /// this function receives the final assert result
-  virtual void assert_formula(SmtTermInfoVlgPtr result);
+  virtual void assert_formula(TermPtrT result);
   /// this function receives the final result
   virtual void define_function(const std::string& func_name,
-                               const std::vector<SmtTermInfoVlgPtr>& args,
-                               var_type* ret_type, SmtTermInfoVlgPtr func_body);
+                               const std::vector<TermPtrT>& args,
+                               SortPtrT ret_type, TermPtrT func_body);
 
 #define DECLARE_OPERATOR(name)                                                 \
-  SmtTermInfoVlgPtr mk_##name(const std::string& symbol, var_type* sort,       \
+  TermPtrT mk_##name(const std::string& symbol, SortPtrT sort,       \
                               const std::vector<int>& idx,                     \
-                              const std::vector<SmtTermInfoVlgPtr>& args)
+                              const std::vector<TermPtrT>& args)
 
   // I hope it will expand lexically
   DECLARE_OPERATOR(true);

--- a/include/ilang/smt-inout/smt_ast.h
+++ b/include/ilang/smt-inout/smt_ast.h
@@ -81,11 +81,15 @@ struct line_comment : public smt_item {
 /// the type Bool or (_ BitVec)
 struct var_type {
   /// type
-  enum tp { Bool, BV, Datatype } _type;
+  enum tp { Bool, BV, Datatype, Array } _type;
   /// bitwidth
   unsigned _width;
   /// its datatype name (not including | _s|)
   std::string module_name;
+  /// array datatype : addr width
+  unsigned addr_width;
+  /// array datatype : addr width
+  unsigned data_width;
   // ------------- FUNCTIONS ---------------- //
   /// contruct from
   static var_type ParseFromString(str_iterator&); // will update the iterator
@@ -98,17 +102,21 @@ struct var_type {
   static bool eqtype(const var_type& l, const var_type& r);
   /// return a verilog-use width
   unsigned GetBoolBvWidth() const;
+  /// test if it is array
+  bool is_array() const;
   /// test if it is bv
   bool is_bv() const;
-  /// test if it is bv
+  /// test if it is bool
   bool is_bool() const;
-  /// test if it is bv
+  /// test if it is datatype
   bool is_datatype() const;
   // ------------- CONSTRUCTOR ---------------- //
   // default constructor
   var_type();
-  // complete constructor
+  // bitvector/bool constructor : 
   var_type(tp vtype, unsigned width, const std::string mod_name);
+  // array constructor
+  var_type(tp vtype, unsigned addr_width, unsigned data_width, const std::string mod_name);
   // copy constructor
   var_type(const var_type& vp);
   // assignment operator

--- a/include/ilang/smt-inout/smt_ast.h
+++ b/include/ilang/smt-inout/smt_ast.h
@@ -84,12 +84,12 @@ struct var_type {
   enum tp { Bool, BV, Datatype, Array } _type;
   /// bitwidth
   unsigned _width;
-  /// its datatype name (not including | _s|)
-  std::string module_name;
   /// array datatype : addr width
   unsigned addr_width;
   /// array datatype : addr width
   unsigned data_width;
+  /// its datatype name (not including | _s|)
+  std::string module_name;
   // ------------- FUNCTIONS ---------------- //
   /// contruct from
   static var_type ParseFromString(str_iterator&); // will update the iterator

--- a/include/ilang/smt-inout/smt_op.h
+++ b/include/ilang/smt-inout/smt_op.h
@@ -17,63 +17,64 @@
 #define CHECK_BOOL_ONE_ARG(idx, args)                                          \
   ILA_ASSERT(idx.empty());                                                     \
   ILA_ASSERT(args.size() == 1);                                                \
-  ILA_ASSERT(args[0]->_type.is_bool())
+  ILA_ASSERT(get_term(args[0])._type.is_bool())
 
 #define CHECK_BOOL_TWO_ARG(idx, args)                                          \
   ILA_ASSERT((idx).empty());                                                   \
   ILA_ASSERT((args).size() == 2);                                              \
-  ILA_ASSERT((args)[0]->_type.is_bool());                                      \
-  ILA_ASSERT((args)[1]->_type.is_bool())
+  ILA_ASSERT(get_term((args)[0])._type.is_bool());                             \
+  ILA_ASSERT(get_term((args)[1])._type.is_bool())
 
 #define CHECK_BV_TWO_ARG(idx, args)                                            \
   ILA_ASSERT((idx).empty());                                                   \
   ILA_ASSERT((args).size() == 2);                                              \
-  ILA_ASSERT((args)[0]->_type._type == var_type::tp::BV);                      \
-  ILA_ASSERT((args)[1]->_type._type == var_type::tp::BV);                      \
-  ILA_ASSERT(var_type::eqtype((args)[0]->_type, (args)[1]->_type))
+  ILA_ASSERT(get_term((args)[0])._type.is_bv());                               \
+  ILA_ASSERT(get_term((args)[1])._type.is_bv());                               \
+  ILA_ASSERT(var_type::eqtype(get_term((args)[0])._type, get_term((args)[1])._type))
 
 #define CHECK_BV_COMPARE(idx, args) CHECK_BV_TWO_ARG(idx, args)
 
 #define CHECK_BV_ONE_ARG(idx, args)                                            \
   ILA_ASSERT(idx.empty());                                                     \
   ILA_ASSERT(args.size() == 1);                                                \
-  ILA_ASSERT(args[0]->_type._type == var_type::tp::BV);
+  ILA_ASSERT(get_term(args[0])._type.is_bv());
 
 #define CHECK_BV_TWO_ARG_DIFF_WIDTH(idx, args)                                 \
   ILA_ASSERT((idx).empty());                                                   \
   ILA_ASSERT((args).size() == 2);                                              \
-  ILA_ASSERT((args)[0]->_type._type == var_type::tp::BV);                      \
-  ILA_ASSERT((args)[1]->_type._type == var_type::tp::BV);
+  ILA_ASSERT(get_term((args)[0])._type.is_bv());                               \
+  ILA_ASSERT(get_term((args)[1])._type.is_bv());
 
 #define MAKE_BOOL_RESULT(vlg_expr)                                             \
   std::string search_name = "##bool_" + (vlg_expr);                            \
-  if (!IN(search_name, term_container)) {                                      \
-    term_container.insert(std::make_pair(                                      \
+  if (!IN(search_name, name2term_map)) {                                       \
+    return new_term(                                                           \
         search_name,                                                           \
         SmtTermInfoVerilog((vlg_expr), var_type(var_type::tp::Bool, 1, ""),    \
-                           this)));                                            \
+                           this));                                             \
   }                                                                            \
-  return &(term_container[search_name])
+  return (name2term_map.at(search_name))
 
 #define MAKE_MULTI_OP(vlg_expr, args, TYPE, op)                                \
   bool first = true;                                                           \
   for (auto&& arg : (args)) {                                                  \
-    ILA_ASSERT(arg->_type._type == (TYPE));                                    \
+    const auto & t = get_term(arg);                                            \
+    ILA_ASSERT(t._type._type == (TYPE));                                       \
     if (first)                                                                 \
-      (vlg_expr) = "(" + arg->_translate + ")";                                \
+      (vlg_expr) = "(" +t._translate + ")";                                    \
     else                                                                       \
-      (vlg_expr) += " " op "(" + arg->_translate + ")";                        \
+      (vlg_expr) += " " op "(" + t._translate + ")";                           \
     first = false;                                                             \
   }
 
 #define MAKE_BV_RESULT_TYPE_AS_ARGN(vlg_expr, args, n)                         \
   std::string search_name =                                                    \
-      "##bv" + std::to_string(args[(n)]->_type._width) + "_" + (vlg_expr);     \
-  if (!IN(search_name, term_container)) {                                      \
-    term_container.insert(std::make_pair(                                      \
-        search_name, SmtTermInfoVerilog(vlg_expr, args[(n)]->_type, this)));   \
+      "##bv" + std::to_string(get_term(args[(n)])._type._width) + "_" + (vlg_expr);     \
+  if (!IN(search_name, name2term_map)) {                                       \
+    return new_term(                                      \
+        search_name, SmtTermInfoVerilog(vlg_expr, get_term(args[(n)])._type, this));   \
   }                                                                            \
-  return &(term_container[search_name])
+  return (name2term_map.at(search_name))
 
 #define MAKE_BV_RESULT_TYPE_AS_ARG0(vlg_expr, args)                            \
   MAKE_BV_RESULT_TYPE_AS_ARGN(vlg_expr, args, 0)

--- a/include/ilang/smt-inout/smt_op.h
+++ b/include/ilang/smt-inout/smt_op.h
@@ -5,45 +5,45 @@
 #define SMT_OP_H__
 
 #define CHECK_EMPTY_PARAM(idx, args)                                           \
-  ILA_ASSERT((idx).empty());                                                   \
-  ILA_ASSERT((args).empty())
+  ILA_CHECK((idx).empty());                                                   \
+  ILA_CHECK((args).empty())
 
 #define CHECK_BV_MULTI_ARG(idx, args)                                          \
-  ILA_ASSERT((idx).empty());                                                   \
-  ILA_ASSERT((args).size() >= 2);
+  ILA_CHECK((idx).empty());                                                   \
+  ILA_CHECK((args).size() >= 2);
 
 #define CHECK_BOOL_MULTI_ARG(idx, args) CHECK_BV_MULTI_ARG(idx, args)
 
 #define CHECK_BOOL_ONE_ARG(idx, args)                                          \
-  ILA_ASSERT(idx.empty());                                                     \
-  ILA_ASSERT(args.size() == 1);                                                \
-  ILA_ASSERT(get_term(args[0])._type.is_bool())
+  ILA_CHECK(idx.empty());                                                     \
+  ILA_CHECK(args.size() == 1);                                                \
+  ILA_CHECK(get_term(args[0])._type.is_bool())
 
 #define CHECK_BOOL_TWO_ARG(idx, args)                                          \
-  ILA_ASSERT((idx).empty());                                                   \
-  ILA_ASSERT((args).size() == 2);                                              \
-  ILA_ASSERT(get_term((args)[0])._type.is_bool());                             \
-  ILA_ASSERT(get_term((args)[1])._type.is_bool())
+  ILA_CHECK((idx).empty());                                                   \
+  ILA_CHECK((args).size() == 2);                                              \
+  ILA_CHECK(get_term((args)[0])._type.is_bool());                             \
+  ILA_CHECK(get_term((args)[1])._type.is_bool())
 
 #define CHECK_BV_TWO_ARG(idx, args)                                            \
-  ILA_ASSERT((idx).empty());                                                   \
-  ILA_ASSERT((args).size() == 2);                                              \
-  ILA_ASSERT(get_term((args)[0])._type.is_bv());                               \
-  ILA_ASSERT(get_term((args)[1])._type.is_bv());                               \
-  ILA_ASSERT(var_type::eqtype(get_term((args)[0])._type, get_term((args)[1])._type))
+  ILA_CHECK((idx).empty());                                                   \
+  ILA_CHECK((args).size() == 2);                                              \
+  ILA_CHECK(get_term((args)[0])._type.is_bv());                               \
+  ILA_CHECK(get_term((args)[1])._type.is_bv());                               \
+  ILA_CHECK(var_type::eqtype(get_term((args)[0])._type, get_term((args)[1])._type))
 
 #define CHECK_BV_COMPARE(idx, args) CHECK_BV_TWO_ARG(idx, args)
 
 #define CHECK_BV_ONE_ARG(idx, args)                                            \
-  ILA_ASSERT(idx.empty());                                                     \
-  ILA_ASSERT(args.size() == 1);                                                \
-  ILA_ASSERT(get_term(args[0])._type.is_bv());
+  ILA_CHECK(idx.empty());                                                     \
+  ILA_CHECK(args.size() == 1);                                                \
+  ILA_CHECK(get_term(args[0])._type.is_bv());
 
 #define CHECK_BV_TWO_ARG_DIFF_WIDTH(idx, args)                                 \
-  ILA_ASSERT((idx).empty());                                                   \
-  ILA_ASSERT((args).size() == 2);                                              \
-  ILA_ASSERT(get_term((args)[0])._type.is_bv());                               \
-  ILA_ASSERT(get_term((args)[1])._type.is_bv());
+  ILA_CHECK((idx).empty());                                                   \
+  ILA_CHECK((args).size() == 2);                                              \
+  ILA_CHECK(get_term((args)[0])._type.is_bv());                               \
+  ILA_CHECK(get_term((args)[1])._type.is_bv());
 
 #define MAKE_BOOL_RESULT(vlg_expr)                                             \
   std::string search_name = "##bool_" + (vlg_expr);                            \
@@ -59,7 +59,7 @@
   bool first = true;                                                           \
   for (auto&& arg : (args)) {                                                  \
     const auto & t = get_term(arg);                                            \
-    ILA_ASSERT(t._type._type == (TYPE));                                       \
+    ILA_CHECK(t._type._type == (TYPE));                                       \
     if (first)                                                                 \
       (vlg_expr) = "(" +t._translate + ")";                                    \
     else                                                                       \

--- a/include/ilang/vtarget-out/inv-syn/grain_inv_parse.h
+++ b/include/ilang/vtarget-out/inv-syn/grain_inv_parse.h
@@ -56,12 +56,9 @@ public:
 
   // -------------- CALLBACK FNs ------------------- //
 
-  /// override!
-  /// call back function to create a sort
-  virtual var_type* make_sort(const std::string& name,
-                              const std::vector<int>&) override;
+
   /// this is actually declare variables
-  void declare_function(const std::string& name, var_type* sort) override;
+  virtual void declare_function(const std::string& name, SortPtrT sort) override;
 
   /// this function receives the final assert result
   // virtual void assert_formula(SmtTermInfoVlgPtr result) override; -- use the
@@ -69,33 +66,29 @@ public:
 
   // -------------- Below are Disabled!--------------------- //
   /// call back function to handle (define-fun
-  virtual SmtTermInfoVlgPtr push_quantifier_scope() override;
+  virtual TermPtrT push_quantifier_scope() override;
   /// call back function to handle ) of define-fun
-  virtual SmtTermInfoVlgPtr pop_quantifier_scope() override;
+  virtual TermPtrT pop_quantifier_scope() override;
 
   /// call back function to create a temporary (function-arg variable)
   virtual void declare_quantified_variable(const std::string& name,
-                                           var_type* sort) override;
+                                           SortPtrT sort) override;
   /// call back function to apply an uninterpreted function
   /// fall-through case if it is not an defined op, if failed, return NULL
-  virtual SmtTermInfoVlgPtr
-  mk_function(const std::string& name, var_type* sort,
+  virtual TermPtrT
+  mk_function(const std::string& name, SortPtrT sort,
               const std::vector<int>& idx,
-              const std::vector<SmtTermInfoVlgPtr>& args) override;
+              const std::vector<TermPtrT>& args) override;
 
   /// call back function to make a number term
   // virtual SmtTermInfoVlgPtr mk_number(const std::string & rep, int width, int
   // base) override;
 
-  /// find if a certain var is a function-arg variable
-  virtual SmtTermInfoVlgPtr
-  search_quantified_var_stack(const std::string& name) override;
-
   /// this function receives the final result
   virtual void define_function(const std::string& func_name,
-                               const std::vector<SmtTermInfoVlgPtr>& args,
-                               var_type* ret_type,
-                               SmtTermInfoVlgPtr func_body) override;
+                               const std::vector<TermPtrT>& args,
+                               SortPtrT ret_type,
+                               TermPtrT func_body) override;
 
 }; // class GrainInvariantParser
 

--- a/src/smt-inout/chc_inv_callback_fn.cc
+++ b/src/smt-inout/chc_inv_callback_fn.cc
@@ -32,8 +32,8 @@ template <class T> std::vector<T> make_vector(smtlib2_vector* iv) {
 
 // ------------------ CALL BACK FUNCTIONS ------------- //
 
-smtlib2_term proxy_push_quantifier_scope(smtlib2_parser_interface* p) {
-  return (smtlib2_term)(PARSER(p)->push_quantifier_scope());
+void proxy_push_quantifier_scope(smtlib2_parser_interface* p) {
+  (PARSER(p)->push_quantifier_scope());
 }
 
 smtlib2_term proxy_pop_quantifier_scope(smtlib2_parser_interface* p) {

--- a/src/smt-inout/chc_inv_in.cc
+++ b/src/smt-inout/chc_inv_in.cc
@@ -250,14 +250,14 @@ SmtlibInvariantParser::make_sort(const std::string& name,
       }
       return name2sort_map.at("Bool");
     } else if (name == "BitVec") {
-      ILA_ASSERT(idx.size() == 1);
-      ILA_ASSERT(idx[0] > 0);
+      ILA_CHECK(idx.size() == 1);
+      ILA_CHECK(idx[0] > 0);
       std::string sortIdxName = "BV" + std::to_string(idx[0]);
       if (!IN(sortIdxName, name2sort_map)) 
         return new_sort(sortIdxName, var_type(var_type::tp::BV, idx[0], ""));
       return name2sort_map.at(sortIdxName);
     }
-    ILA_ASSERT(false) << "Unknown sort:" << name << " in flattened smt.";
+    ILA_CHECK(false) << "Unknown sort:" << name << " in flattened smt.";
     return 0; // should not be reachable
   } else {
     // if not flattened, there should only be one sort
@@ -363,7 +363,7 @@ SmtlibInvariantParser::mk_function(const std::string& name, SortPtrT sort,
     auto term_ptr = search_quantified_var_stack(name);
     if (term_ptr)
       return term_ptr;
-    ILA_ASSERT(false) << "unknown symbol:" << name;
+    ILA_CHECK(false) << "unknown symbol:" << name;
     return 0; // no use
   }
   // if it is function call
@@ -392,7 +392,7 @@ SmtlibInvariantParser::mk_function(const std::string& name, SortPtrT sort,
         else if (dt._type.is_bv())
           search_name = "##bv" + std::to_string(dt._type._width) + "_";
         else
-          ILA_ASSERT(false) << "unexpected type!";
+          ILA_CHECK(false) << "unexpected type!";
 
         search_name += dt.verilog_name;
         auto repl_name = dt.verilog_name;
@@ -423,7 +423,7 @@ SmtlibInvariantParser::mk_function(const std::string& name, SortPtrT sort,
         return name2term_map.at(search_name);
       } // if name matched
     }   // for all datatypes
-    ILA_ASSERT(false) << "unknown symbol:" << name;
+    ILA_CHECK(false) << "unknown symbol:" << name;
     return 0; // should not be reachable
   }                 // end of else
 } // mk_function
@@ -432,7 +432,7 @@ SmtlibInvariantParser::mk_function(const std::string& name, SortPtrT sort,
 SmtlibInvariantParser::TermPtrT 
 SmtlibInvariantParser::mk_number(const std::string& rep,
                                                    int width, int base) {
-  ILA_ASSERT(width > 0) << "Unable to translate Integer!";
+  ILA_CHECK(width > 0) << "Unable to translate Integer with width <=0!";
   char radix;
   switch (base) {
   case 2:
@@ -445,7 +445,7 @@ SmtlibInvariantParser::mk_number(const std::string& rep,
     radix = 'h';
     break;
   default:
-    ILA_ASSERT(false) << "unable to handle base:" << base;
+    ILA_CHECK(false) << "unable to handle base:" << base;
   }
   std::string vlg_expr = std::to_string(width) + "'" + radix + rep;
   std::string name = "##bv" + vlg_expr;
@@ -505,11 +505,11 @@ DEFINE_OPERATOR(implies) {
 }
 
 DEFINE_OPERATOR(eq) {
-  ILA_ASSERT(idx.empty());
-  ILA_ASSERT(args.size() == 2); // we don't require they are bv
+  ILA_CHECK(idx.empty());
+  ILA_CHECK(args.size() == 2); // we don't require they are bv
   const auto & t0 = get_term(args[0]);
   const auto & t1 = get_term(args[1]);
-  ILA_ASSERT(var_type::eqtype(t0._type, t1._type));
+  ILA_CHECK(var_type::eqtype(t0._type, t1._type));
 
 
   std::string vlg_expr =
@@ -518,13 +518,13 @@ DEFINE_OPERATOR(eq) {
   MAKE_BOOL_RESULT(vlg_expr);
 }
 DEFINE_OPERATOR(ite) {
-  ILA_ASSERT(idx.empty());
-  ILA_ASSERT(args.size() == 3);
+  ILA_CHECK(idx.empty());
+  ILA_CHECK(args.size() == 3);
   const auto & t0 = get_term(args[0]);
   const auto & t1 = get_term(args[1]);
   const auto & t2 = get_term(args[2]);
-  ILA_ASSERT(t0._type.is_bool());
-  ILA_ASSERT(var_type::eqtype(t1._type, t2._type));
+  ILA_CHECK(t0._type.is_bool());
+  ILA_CHECK(var_type::eqtype(t1._type, t2._type));
 
   auto vlg_expr = "(" + t0._translate + ") ? (" + t1._translate +
                   ") : (" + t2._translate + ")";
@@ -551,8 +551,8 @@ DEFINE_OPERATOR (xor) {
 } // xor
 
 DEFINE_OPERATOR(nand) {
-  ILA_ASSERT(idx.empty());
-  ILA_ASSERT(args.size() >= 2);
+  ILA_CHECK(idx.empty());
+  ILA_CHECK(args.size() >= 2);
 
   std::string vlg_expr;
   MAKE_MULTI_OP(vlg_expr, args, var_type::tp::Bool, "&&");
@@ -562,15 +562,15 @@ DEFINE_OPERATOR(nand) {
 } // nand
 
 DEFINE_OPERATOR(concat) {
-  ILA_ASSERT(idx.empty());
-  ILA_ASSERT(args.size() >= 2);
+  ILA_CHECK(idx.empty());
+  ILA_CHECK(args.size() >= 2);
 
   std::string vlg_expr = "{";
   unsigned total_width = 0;
   bool first = true;
   for (auto&& arg : (args)) {
     const auto & t = get_term(arg);
-    ILA_ASSERT(t._type.is_bv());
+    ILA_CHECK(t._type.is_bv());
     if (first)
       (vlg_expr) += t._translate;
     else
@@ -792,7 +792,7 @@ DEFINE_OPERATOR(bvurem) {
 } // bvurem
 
 DEFINE_OPERATOR(bvsrem) {
-  ILA_ASSERT(false) << "Unimplemented";
+  ILA_CHECK(false) << "Unimplemented";
   return 0;
 
   // CHECK_BV_TWO_ARG(idx,args);
@@ -830,19 +830,19 @@ DEFINE_OPERATOR(bvashr) {
 } // bvashr
 
 DEFINE_OPERATOR(extract) {
-  ILA_ASSERT(idx.size() == 2);
-  ILA_ASSERT(args.size() == 1);
+  ILA_CHECK(idx.size() == 2);
+  ILA_CHECK(args.size() == 1);
   const auto & arg0 = get_term(args[0]);
-  ILA_ASSERT(arg0._type.is_bv());
+  ILA_CHECK(arg0._type.is_bv());
   // || (args[0]->_type.is_bool() && idx[0] == 0 && idx[1] == 0 ) smt should ensure it is bv
-  ILA_ASSERT(idx[0] >= 0 && idx[1] >= 0);
+  ILA_CHECK(idx[0] >= 0 && idx[1] >= 0);
 
   unsigned left = idx[0];
   unsigned right = idx[1];
   unsigned new_width = std::max(left, right) - std::min(left, right) + 1;
-  ILA_ASSERT(new_width <= arg0._type._width);
-  ILA_ASSERT(idx[0] >= 0 && left < arg0._type._width);  // left >= 0, always true
-  ILA_ASSERT(idx[1] >= 0 && right < arg0._type._width); // right >= 0
+  ILA_CHECK(new_width <= arg0._type._width);
+  ILA_CHECK(idx[0] >= 0 && left < arg0._type._width);  // left >= 0, always true
+  ILA_CHECK(idx[1] >= 0 && right < arg0._type._width); // right >= 0
 
   std::string bitslice =
       "[" + std::to_string(left) + ":" + std::to_string(right) + "]";
@@ -892,14 +892,14 @@ DEFINE_OPERATOR(extract) {
 } // extract
 
 DEFINE_OPERATOR(bit2bool) {
-  ILA_ASSERT(idx.size() == 1);
-  ILA_ASSERT(args.size() == 1);
+  ILA_CHECK(idx.size() == 1);
+  ILA_CHECK(args.size() == 1);
   const auto & arg0 = get_term(args[0]);
-  ILA_ASSERT(arg0._type.is_bv());
-  ILA_ASSERT(idx[0] >= 0);
+  ILA_CHECK(arg0._type.is_bv());
+  ILA_CHECK(idx[0] >= 0);
 
   unsigned bitidx = idx[0];
-  ILA_ASSERT(idx[0] >= 0 && bitidx < arg0._type._width);
+  ILA_CHECK(idx[0] >= 0 && bitidx < arg0._type._width);
   // auto bitslice = "[" + std::to_string(bitidx)  + "]";
   auto bitslice =
       "[" + std::to_string(bitidx) + ":" + std::to_string(bitidx) + "]";
@@ -944,11 +944,11 @@ DEFINE_OPERATOR(bit2bool) {
 } // bit2bool
 
 DEFINE_OPERATOR(repeat) {
-  ILA_ASSERT(idx.size() == 1);
-  ILA_ASSERT(args.size() == 1);
+  ILA_CHECK(idx.size() == 1);
+  ILA_CHECK(args.size() == 1);
   const auto & arg0 = get_term(args[0]);
-  ILA_ASSERT(arg0._type.is_bv());
-  ILA_ASSERT(idx[0] > 0);
+  ILA_CHECK(arg0._type.is_bv());
+  ILA_CHECK(idx[0] > 0);
   auto n_times = idx[0];
   auto new_width = n_times * arg0._type.GetBoolBvWidth();
 
@@ -962,13 +962,13 @@ DEFINE_OPERATOR(repeat) {
 }
 
 DEFINE_OPERATOR(zero_extend) {
-  ILA_ASSERT(idx.size() == 1);
-  ILA_ASSERT(args.size() == 1);
+  ILA_CHECK(idx.size() == 1);
+  ILA_CHECK(args.size() == 1);
   const auto & t = get_term(args[0]);
-  ILA_ASSERT(t._type.is_bv());
+  ILA_CHECK(t._type.is_bv());
   auto extraw = idx[0];
   auto new_width = extraw + t._type.GetBoolBvWidth();
-  ILA_ASSERT(extraw > 0);
+  ILA_CHECK(extraw > 0);
   std::string vlg_expr = "{" + IntToStrCustomBase(extraw,10,false) + "'d0," + t._translate + "}";
   std::string search_name = "##bvzext" + std::to_string(new_width) + "{" + t._translate + "}";
   if (!IN(search_name, name2term_map)) {
@@ -978,14 +978,14 @@ DEFINE_OPERATOR(zero_extend) {
 }
 
 DEFINE_OPERATOR(sign_extend) {
-  ILA_ASSERT(idx.size() == 1);
-  ILA_ASSERT(args.size() == 1);
+  ILA_CHECK(idx.size() == 1);
+  ILA_CHECK(args.size() == 1);
   const auto & t = get_term(args[0]);
-  ILA_ASSERT(t._type.is_bv());
+  ILA_CHECK(t._type.is_bv());
   auto extraw = idx[0];
   auto oldw = t._type.GetBoolBvWidth();
   auto new_width = extraw + oldw;
-  ILA_ASSERT(extraw > 0);
+  ILA_CHECK(extraw > 0);
   TermPtrT inner_term_no = mk_extract("", 0, {(int)(oldw)-1,(int)(oldw)-1},{args[0]});//?;
   const auto & inner_term = get_term(inner_term_no);
   std::string vlg_expr = "{{" + IntToStrCustomBase(extraw,10,false) + "{" + inner_term._translate + "}}," + t._translate + "}";
@@ -996,11 +996,11 @@ DEFINE_OPERATOR(sign_extend) {
   return name2term_map.at(search_name);
 }
 DEFINE_OPERATOR(rotate_left) {
-  ILA_ASSERT(false) << "Unimplemented";
+  ILA_CHECK(false) << "Unimplemented";
   return 0;
 }
 DEFINE_OPERATOR(rotate_right) {
-  ILA_ASSERT(false) << "Unimplemented";
+  ILA_CHECK(false) << "Unimplemented";
   return 0;
 }
 

--- a/src/smt-inout/chc_inv_in.cc
+++ b/src/smt-inout/chc_inv_in.cc
@@ -309,7 +309,6 @@ void SmtlibInvariantParser::declare_quantified_variable(const std::string& name,
   ILA_ASSERT(!quantifier_def_stack.empty());
   ILA_ASSERT(!quantifier_var_def_idx_stack.empty());
   // I assume it has nothing to do with hierarchy flattening
-  auto& top = quantifier_def_stack.back();
   if (datatype_flattened) {
     // we need to extract the name from verilog
     auto top_module = design_smt_info_ptr->get_module_def_orders().back();
@@ -366,7 +365,7 @@ SmtlibInvariantParser::mk_function(const std::string& name, SortPtrT sort,
   // if it is function call
   if (datatype_flattened) {
     if (IN(name, inv_pred_name))
-      return mk_true("true", NULL, {}, {});
+      return mk_true("true", 0, {}, {});
     ILA_CHECK(false) << "Fun:" << name << " called in flattened smt.";
     return 0; // should not be reachable
   } else {
@@ -375,7 +374,7 @@ SmtlibInvariantParser::mk_function(const std::string& name, SortPtrT sort,
     ILA_CHECK(t._type.is_datatype());
 
     if (IN(name, inv_pred_name))
-      return mk_true("true", NULL, {}, {});
+      return mk_true("true", 0, {}, {});
 
     // get it from the module_name
     const auto& module_name = t._type.module_name;

--- a/src/vtarget-out/inv-syn/inv_obj.cc
+++ b/src/vtarget-out/inv-syn/inv_obj.cc
@@ -113,9 +113,10 @@ bool InvariantObject::AddInvariantFromChcResultFile(
   smt_formula_vec.push_back(raw_smt);
 
   for (auto&& name_vlg_pair : parser.GetLocalVarDefs()) {
+    const auto & t = parser.get_term(name_vlg_pair.second);
     inv_extra_vlg_vars.push_back(
-        std::make_tuple(name_vlg_pair.first, name_vlg_pair.second._translate,
-                        name_vlg_pair.second._type.GetBoolBvWidth()));
+        std::make_tuple(name_vlg_pair.first, t._translate,
+                        t._type.GetBoolBvWidth()));
   }
   for (auto&& name_w_pair : parser.GetFreeVarDefs()) {
     if (IN(name_w_pair.first, inv_extra_free_vars))
@@ -154,9 +155,10 @@ void InvariantObject::AddInvariantFromGrainResultFile(
   smt_formula_vec.push_back(""); // although we get it, we remove it here
 
   for (auto&& name_vlg_pair : parser.GetLocalVarDefs()) {
+    const auto & t = parser.get_term(name_vlg_pair.second);
     inv_extra_vlg_vars.push_back(
-        std::make_tuple(name_vlg_pair.first, name_vlg_pair.second._translate,
-                        name_vlg_pair.second._type.GetBoolBvWidth()));
+        std::make_tuple(name_vlg_pair.first, t._translate,
+                        t._type.GetBoolBvWidth()));
   }
   for (auto&& name_w_pair : parser.GetFreeVarDefs()) {
     if (IN(name_w_pair.first, inv_extra_free_vars))

--- a/test/t_inv_syn.cc
+++ b/test/t_inv_syn.cc
@@ -837,6 +837,7 @@ TEST_F(TestVlgVerifInvSyn, SimpleCntRelChc) {
 
   VerilogVerificationTargetGenerator::vtg_config_t cfg;
   cfg.CosaAddKeep = false;
+  cfg.YosysPath = "N/A";
   cfg.YosysSmtFlattenHierarchy = false;
 
   auto dirName = std::string(ILANG_TEST_SRC_ROOT) + "/unit-data/inv_syn/cnt2/";
@@ -858,6 +859,7 @@ TEST_F(TestVlgVerifInvSyn, SimpleCntRelChcNoStart) {
 
   VerilogVerificationTargetGenerator::vtg_config_t cfg;
   cfg.CosaAddKeep = false;
+  cfg.YosysPath = "N/A";
   cfg.YosysSmtFlattenHierarchy = false;
   cfg.VerificationSettingAvoidIssueStage = true;
 

--- a/test/unit-data/inv_extract/z3/__synthesis_result.txt
+++ b/test/unit-data/inv_extract/z3/__synthesis_result.txt
@@ -1,19 +1,19 @@
 unsat
 (forall ((A wrapper_s))
-  (let ((a!1 (or ((_ bit2bool 1) (|wrapper#4| A))
-                 (not ((_ bit2bool 0) (|wrapper#4| A)))
-                 ((_ bit2bool 0) (|wrapper#6| A))
-                 ((_ bit2bool 1) (|wrapper#6| A))))
-        (a!2 (or ((_ bit2bool 1) (|wrapper#4| A))
-                 (not ((_ bit2bool 0) (|wrapper#6| A)))
-                 ((_ bit2bool 1) (|wrapper#6| A))
-                 ((_ bit2bool 0) (|wrapper#4| A))))
-        (a!3 (or ((_ bit2bool 0) (|wrapper#4| A))
-                 (not ((_ bit2bool 0) (|wrapper#6| A)))
-                 (not ((_ bit2bool 1) (|wrapper#6| A)))
-                 (not ((_ bit2bool 1) (|wrapper#4| A)))))
-        (a!4 (or ((_ bit2bool 0) (|wrapper#6| A))
-                 (not ((_ bit2bool 1) (|wrapper#6| A)))
-                 (not ((_ bit2bool 0) (|wrapper#4| A)))
-                 (not ((_ bit2bool 1) (|wrapper#4| A))))))
+  (let ((a!1 (or ((_ bit2bool 1) (|wrapper#4| A))           ; imp[1]
+                 (not ((_ bit2bool 0) (|wrapper#4| A)))     ; !imp[0]
+                 ((_ bit2bool 0) (|wrapper#6| A))           ; v[0]
+                 ((_ bit2bool 1) (|wrapper#6| A))))         ; v[1]
+        (a!2 (or ((_ bit2bool 1) (|wrapper#4| A))           ; imp[1]
+                 (not ((_ bit2bool 0) (|wrapper#6| A)))     ; !v[0]
+                 ((_ bit2bool 1) (|wrapper#6| A))           ; v[1]
+                 ((_ bit2bool 0) (|wrapper#4| A))))         ; imp[0]
+        (a!3 (or ((_ bit2bool 0) (|wrapper#4| A))           ; imp[0]
+                 (not ((_ bit2bool 0) (|wrapper#6| A)))     ; !v[0]
+                 (not ((_ bit2bool 1) (|wrapper#6| A)))     ; !v[1]
+                 (not ((_ bit2bool 1) (|wrapper#4| A)))))   ; !imp[1]
+        (a!4 (or ((_ bit2bool 0) (|wrapper#6| A))           ; v[0]
+                 (not ((_ bit2bool 1) (|wrapper#6| A)))     ; !v[1]
+                 (not ((_ bit2bool 0) (|wrapper#4| A)))     ; !imp[0]
+                 (not ((_ bit2bool 1) (|wrapper#4| A))))))  ; !imp[1]
     (= (INV A) (and a!1 a!2 a!3 a!4))))


### PR DESCRIPTION
Attempt to fix the Heisenbug on MacOS release build. #190 

The changes here are basically 
* replacing pointers with indices to refer to elements inside containers (I think this was the main reason for the memory corruption as those pointers became invalid when containers reallocate to hold more elements)
* fixing function pointer signature mismatch
